### PR TITLE
Enable automatic Pages deployment

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,41 @@
+name: Deploy UI to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - uses: actions/configure-pages@v4
+      - run: npm ci
+      - run: npm run ui:build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ui-dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
 export default defineConfig({
   plugins: [react()],
   root: ".",
+  base: isGitHubActions ? "./" : "/",
   build: {
     outDir: "ui-dist",
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the React UI and deploys it to GitHub Pages on every main push
- adjust Vite configuration to emit relative asset paths when running inside GitHub Actions