### PR TITLE
Fix Pages workflow provisioning

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: 20
           cache: 'npm'
       - uses: actions/configure-pages@v4
+        with:
+          enablement: true
       - run: npm ci
       - run: npm run ui:build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- enable site provisioning in the GitHub Pages workflow so configure-pages succeeds on first run