### PR TITLE
Adjust workflow permissions for Pages

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  administration: write
 
 concurrency:
   group: "pages"


### PR DESCRIPTION
## Summary
- grant the workflow administration permission so configure-pages can provision the site