### PR TITLE
Deploy via gh-pages branch

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -6,17 +6,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-  administration: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  contents: write
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,21 +17,10 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - uses: actions/configure-pages@v4
-        with:
-          enablement: true
       - run: npm ci
       - run: npm run ui:build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: ui-dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: ui-dist
+          clean: true


### PR DESCRIPTION
## Summary
- replace the Pages deployment workflow with JamesIves/github-pages-deploy-action
- publish the built UI to the gh-pages branch so GitHub Pages serves it