### PR TITLE
Add GitHub Pages link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Vivaldi の SVG アイコンを着色・非活性化するためのツールキ�
 - `dist/` – `npm run build` 後に生成される JavaScript バンドル
 - `output/` – CLI 実行時の出力先（生成物は Git 管理対象外）
 
-公開中の UI プレビュー: [https://tkhashi.github.io/vivaldi-icon-maker/](https://tkhashi.github.io/vivaldi-icon-maker/)
+## UI プレビュー
+
+GitHub Pages 上で React UI を利用できます:
+
+- https://tkhashi.github.io/vivaldi-icon-maker/
 
 ## セットアップ
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Vivaldi の SVG アイコンを着色・非活性化するためのツールキ�
 - `dist/` – `npm run build` 後に生成される JavaScript バンドル
 - `output/` – CLI 実行時の出力先（生成物は Git 管理対象外）
 
+公開中の UI プレビュー: [https://tkhashi.github.io/vivaldi-icon-maker/](https://tkhashi.github.io/vivaldi-icon-maker/)
+
 ## セットアップ
 
 ```bash

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -52,6 +52,12 @@ for (const variant of variants) {
 }
 ```
 
+## 関連 UI
+
+GitHub Pages 上で React UI を動かしています。ライブラリの挙動をブラウザから確認したい場合に利用できます。
+
+- https://tkhashi.github.io/vivaldi-icon-maker/
+
 ## サポートユーティリティ
 
 - `svgColorizer.ts` – `recolorVivaldiSvg` と `validateColorInput`


### PR DESCRIPTION
## Summary
- mention the hosted React UI in the root README
- document the same GitHub Pages link in the core library README